### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -74,8 +74,7 @@ jobs:
     needs: build-and-push-image
     environment: 'production'
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
+    permissions: {}
     steps:
       - name: Deploy to production env
         uses: appleboy/ssh-action@v1


### PR DESCRIPTION
Potential fix for [https://github.com/houthacker/nighttune/security/code-scanning/1](https://github.com/houthacker/nighttune/security/code-scanning/1)

To fix the problem, an explicit, minimal `permissions` block should be added to the `deploy-to-production` job. Review what this job actually does: it only uses SSH to connect to a remote host and runs Docker commands, and does not interact with repository contents, packages, issues, etc., so the minimal permissions are `none` (i.e., disable GITHUB_TOKEN entirely for this job, unless interaction is needed in the future). This change should be made in `.github/workflows/docker.yaml` within the `deploy-to-production` job definition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
