### PR TITLE
Migrate metadata to Next.js API

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -2,6 +2,10 @@ import '../src/index.css'
 
 export const metadata = {
     title: 'Nighttune',
+    description: 'Nighttune provides a simple way to run OpenAPS Autotune against Nightscout profiles.',
+    openGraph: {
+        description: 'Nighttune provides a simple way to run OpenAPS Autotune against Nightscout profiles.'
+    }
 }
 
 export default function RootLayout({ children }) {

--- a/src/components/NightscoutInstance.tsx
+++ b/src/components/NightscoutInstance.tsx
@@ -1,6 +1,5 @@
 import Cap, { CapErrorEvent, CapSolveEvent } from '@cap.js/widget'
 import React from 'react'
-import { Helmet } from 'react-helmet'
 
 import { Alert, AlertTitle, Divider, Fade, FormLabel, Grid, InputLabel, Link, List, ListItem, ListItemText, MenuItem, Select, TextField, Typography } from '@mui/material'
 
@@ -20,10 +19,6 @@ const DEFAULT_ALERT_SETTINGS = new AlertInfo(false, undefined, undefined)
 export function InfoText() {
     return ( 
         <>
-            <Helmet>
-                <meta name="description" content="Nighttune provides a simple way to run OpenAPS Autotune against Nightscout profiles." />
-                <meta property="og:description" content="Nighttune provides a simple way to run OpenAPS Autotune against Nightscout profiles." />
-            </Helmet>
             <List sx={{ bgcolor: 'background.paper' }}>
                 <ListItem alignItems="flex-start">
                     <ListItemText


### PR DESCRIPTION
- Move SEO description and OpenGraph tags from react-helmet to the native Next.js metadata API in the root layout.
